### PR TITLE
PR for sourcemap support

### DIFF
--- a/index.js
+++ b/index.js
@@ -28,7 +28,7 @@ module.exports = function (fn, options) {
 			wait,
 			result;
 
-		if(file.isNull()) {
+		if (file.isNull()) {
 
 			callback(null, file);
 			return
@@ -47,8 +47,8 @@ module.exports = function (fn, options) {
 		} else if (file.isBuffer()) {
 
 			if (file.sourceMap) {
-	      options.makeSourceMaps = true;
-	    }
+				options.makeSourceMaps = true;
+			}
 
 			try {
 				result = transformSelector.process(file.contents.toString(), {

--- a/index.js
+++ b/index.js
@@ -1,7 +1,9 @@
 'use strict';
 
 var es = require('event-stream'),
-	postcss = require('postcss');
+	postcss = require('postcss'),
+	applySourceMap = require('vinyl-sourcemaps-apply'),
+	gutil = require('gulp-util');
 
 
 module.exports = function (fn, options) {
@@ -23,7 +25,9 @@ module.exports = function (fn, options) {
 
 	return es.map(function (file, callback) {
 		var through,
-			wait;
+			wait,
+			result;
+
 		if(file.isNull()) {
 
 			callback(null, file);
@@ -41,7 +45,28 @@ module.exports = function (fn, options) {
 			file.contents = through;
 
 		} else if (file.isBuffer()) {
-			file.contents = new Buffer(transformSelector.process(file.contents).css);
+
+			if (file.sourceMap) {
+	      options.makeSourceMaps = true;
+	    }
+
+			try {
+				result = transformSelector.process(file.contents.toString(), {
+					map: file.sourceMap ? {annotation: false} : false,
+					from: file.relative,
+					to: file.relative
+				});
+
+				file.contents = new Buffer(result.css);
+
+				if (result.map && file.sourceMap) {
+					applySourceMap(file, result.map.toString());
+				}
+			} catch (err) {
+				callback(new gutil.PluginError('gulp-transform-selectors', err, {fileName: file.path}));
+				return;
+			}
+
 		}
 
 		callback(null, file);

--- a/index.js
+++ b/index.js
@@ -24,8 +24,12 @@ module.exports = function (fn, options) {
 	return es.map(function (file, callback) {
 		var through,
 			wait;
+		if(file.isNull()) {
 
-		if (file.isStream()) {
+			callback(null, file);
+			return
+
+		} else if (file.isStream()) {
 
 			through = es.through();
 			wait = es.wait(function (err, contents) {

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
   "dependencies": {
     "event-stream": "~3.1.0",
     "gulp-util": "~2.2.0",
-    "postcss": "^0.3.4"
+    "postcss": "^2.2.5",
+    "vinyl-sourcemaps-apply": "^0.1.4"
   },
   "devDependencies": {
     "mocha": "*",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gulp-transform-selectors",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "A plugin for Gulp",
   "keywords": [
     "gulpplugin"

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "email": "",
     "url": "https://github.com/nixonchris"
   },
-  "repository": "nixonchris/gulp-require-convert",
+  "repository": "nixonchris/gulp-transform-selectors",
   "scripts": {
     "test": "istanbul test _mocha --report html -- test/*.js --reporter spec",
     "coveralls": "istanbul cover ./node_modules/mocha/bin/_mocha --report lcovonly -- -R spec && cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js && rm -rf ./coverage"

--- a/package.json
+++ b/package.json
@@ -22,10 +22,11 @@
     "vinyl-sourcemaps-apply": "^0.1.4"
   },
   "devDependencies": {
-    "mocha": "*",
     "coveralls": "*",
-    "mocha-lcov-reporter": "*",
+    "gulp-sourcemaps": "^1.2.2",
     "istanbul": "*",
+    "mocha": "*",
+    "mocha-lcov-reporter": "*",
     "should": "~2.1.0"
   },
   "engines": {

--- a/package.json
+++ b/package.json
@@ -16,9 +16,9 @@
     "coveralls": "istanbul cover ./node_modules/mocha/bin/_mocha --report lcovonly -- -R spec && cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js && rm -rf ./coverage"
   },
   "dependencies": {
-    "event-stream": "~3.1.0",
-    "gulp-util": "~2.2.0",
-    "postcss": "^2.2.5",
+    "event-stream": "^3.3.1",
+    "gulp-util": "^3.0.6",
+    "postcss": "^4.1.13",
     "vinyl-sourcemaps-apply": "^0.1.4"
   },
   "devDependencies": {
@@ -27,7 +27,7 @@
     "istanbul": "*",
     "mocha": "*",
     "mocha-lcov-reporter": "*",
-    "should": "~2.1.0"
+    "should": "^7.0.1"
   },
   "engines": {
     "node": ">=0.8.0",

--- a/test/main.js
+++ b/test/main.js
@@ -101,10 +101,7 @@ describe('gulp-require-convert', function () {
 			contents: fs.readFileSync('test/fixtures/main.css')
 		});
 
-		init
-			.pipe(transformSelectors(testTransformation, {
-				splitOnCommas: true
-			}))
+		init.pipe(transformSelectors(testTransformation, { splitOnCommas: true }))
 			.pipe(write);
 
 		write.on('data', function (newFile) {

--- a/test/main.js
+++ b/test/main.js
@@ -3,7 +3,8 @@
 
 var fs = require('fs'),
 	es = require('event-stream'),
-	should = require('should');
+	should = require('should'),
+	sourcemaps = require('gulp-sourcemaps');
 
 require('mocha');
 
@@ -87,4 +88,33 @@ describe('gulp-require-convert', function () {
 		stream.write(srcFile);
 		stream.end();
 	});
+
+	it('should generate source maps', function (done) {
+
+		var init = sourcemaps.init();
+		var write = sourcemaps.write();
+
+		var srcFile = new gutil.File({
+			path: 'test/fixtures/main.css',
+			cwd: 'test/',
+			base: 'test/fixtures',
+			contents: fs.readFileSync('test/fixtures/main.css')
+		});
+
+		init
+			.pipe(transformSelectors(testTransformation, {
+				splitOnCommas: true
+			}))
+			.pipe(write);
+
+		write.on('data', function (newFile) {
+			var contents = newFile.contents.toString();
+			should(/sourceMappingURL=data:application\/json;base64/.test(contents)).ok;
+			done();
+		});
+
+		init.write(srcFile);
+		init.end();
+	});
 });
+


### PR DESCRIPTION
Fixes #1 

Note: I've added sourcemap support for buffer using the instructions found [here](https://github.com/floridoo/gulp-sourcemaps#plugin-developers-only-how-to-add-source-map-support-to-plugins). For stream I couldn't find a way to make sourcemaps work, none of the other plugins that support `gulp-sourcemaps` allow streaming. Maybe this will change in the future but for now this should suffice.
